### PR TITLE
Implement roster page

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -7,10 +7,18 @@ import { ArticleModule } from './article/article.module';
 import { ProfileModule } from './profile/profile.module';
 import { TagModule } from './tag/tag.module';
 import { UserModule } from './user/user.module';
+import { RosterModule } from './roster/roster.module';
 import ormConfig from '../mikro-orm.config';
 @Module({
   controllers: [AppController],
-  imports: [MikroOrmModule.forRoot(ormConfig), ArticleModule, UserModule, ProfileModule, TagModule],
+  imports: [
+    MikroOrmModule.forRoot(ormConfig),
+    ArticleModule,
+    UserModule,
+    ProfileModule,
+    TagModule,
+    RosterModule,
+  ],
   providers: [],
 })
 export class AppModule implements NestModule, OnModuleInit {

--- a/apps/backend/src/roster/roster.controller.ts
+++ b/apps/backend/src/roster/roster.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { RosterService, RosterRO } from './roster.service';
+
+@ApiBearerAuth()
+@ApiTags('roster')
+@Controller('roster')
+export class RosterController {
+  constructor(private readonly rosterService: RosterService) {}
+
+  @Get()
+  async findAll(): Promise<RosterRO> {
+    return this.rosterService.findAll();
+  }
+}

--- a/apps/backend/src/roster/roster.module.ts
+++ b/apps/backend/src/roster/roster.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { MikroOrmModule } from '@mikro-orm/nestjs';
+import { User } from '../user/user.entity';
+import { Article } from '../article/article.entity';
+import { RosterController } from './roster.controller';
+import { RosterService } from './roster.service';
+
+@Module({
+  imports: [MikroOrmModule.forFeature({ entities: [User, Article] })],
+  controllers: [RosterController],
+  providers: [RosterService],
+})
+export class RosterModule {}

--- a/apps/backend/src/roster/roster.service.ts
+++ b/apps/backend/src/roster/roster.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { EntityManager } from '@mikro-orm/core';
+
+export interface RosterStats {
+  username: string;
+  articleCount: number;
+  favoritesCount: number;
+  firstArticleDate?: Date | null;
+}
+
+export interface RosterRO {
+  roster: RosterStats[];
+}
+
+@Injectable()
+export class RosterService {
+  constructor(private readonly em: EntityManager) {}
+
+  async findAll(): Promise<RosterRO> {
+    const knex = this.em.getConnection().getKnex();
+    const rows = await knex('user as u')
+      .leftJoin('article as a', 'u.id', 'a.author_id')
+      .groupBy('u.id')
+      .select('u.username')
+      .select(knex.raw('COUNT(a.id) as articleCount'))
+      .select(knex.raw('COALESCE(SUM(a.favorites_count),0) as favoritesCount'))
+      .select(knex.raw('MIN(a.created_at) as firstArticleDate'))
+      .orderBy('favoritesCount', 'desc');
+
+    return {
+      roster: rows.map((r: any) => ({
+        username: r.username,
+        articleCount: Number(r.articleCount) || 0,
+        favoritesCount: Number(r.favoritesCount) || 0,
+        firstArticleDate: r.firstArticleDate ? new Date(r.firstArticleDate) : null,
+      })),
+    };
+  }
+}

--- a/libs/core/api-types/src/index.ts
+++ b/libs/core/api-types/src/index.ts
@@ -3,3 +3,4 @@ export * from './lib/user';
 export * from './lib/profile';
 export * from './lib/comment';
 export * from './lib/auth';
+export * from './lib/roster';

--- a/libs/core/api-types/src/lib/roster.ts
+++ b/libs/core/api-types/src/lib/roster.ts
@@ -1,0 +1,10 @@
+export interface RosterEntry {
+  username: string;
+  articleCount: number;
+  favoritesCount: number;
+  firstArticleDate?: string | null;
+}
+
+export interface RosterResponse {
+  roster: RosterEntry[];
+}

--- a/libs/roster/src/index.ts
+++ b/libs/roster/src/index.ts
@@ -1,1 +1,4 @@
 export * from './lib/roster.module';
+export * from './lib/roster.routes';
+export * from './lib/roster.store';
+export * from './lib/roster.service';

--- a/libs/roster/src/lib/roster.component.html
+++ b/libs/roster/src/lib/roster.component.html
@@ -1,1 +1,19 @@
-<p>TODO</p>
+<h1>Conduit Roster</h1>
+<table class="table table-striped" *ngIf="(roster$ | async) as roster">
+  <thead>
+    <tr>
+      <th>Author</th>
+      <th>Articles</th>
+      <th>Favorites</th>
+      <th>First Article</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr *ngFor="let u of roster">
+      <td><a [routerLink]="['/profile', u.username]">{{ u.username }}</a></td>
+      <td>{{ u.articleCount }}</td>
+      <td>{{ u.favoritesCount }}</td>
+      <td>{{ u.firstArticleDate ? (u.firstArticleDate | date:'mediumDate') : '' }}</td>
+    </tr>
+  </tbody>
+</table>

--- a/libs/roster/src/lib/roster.component.ts
+++ b/libs/roster/src/lib/roster.component.ts
@@ -1,11 +1,22 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RosterStoreService } from './roster.store';
+import { provideComponentStore } from '@ngrx/component-store';
 
 @Component({
   selector: 'realworld-roster',
   templateUrl: './roster.component.html',
   styleUrls: [],
-  providers: [],
-  imports: [],
+  providers: [provideComponentStore(RosterStoreService)],
+  imports: [CommonModule],
   standalone: true,
 })
-export class RosterComponent {}
+export class RosterComponent implements OnInit {
+  roster$ = this.store.roster$;
+
+  constructor(private readonly store: RosterStoreService) {}
+
+  ngOnInit(): void {
+    // store initializes automatically
+  }
+}

--- a/libs/roster/src/lib/roster.service.ts
+++ b/libs/roster/src/lib/roster.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from '@realworld/core/http-client';
+import { RosterResponse } from '@realworld/core/api-types';
+
+@Injectable({ providedIn: 'root' })
+export class RosterService {
+  constructor(private apiService: ApiService) {}
+
+  getRoster(): Observable<RosterResponse> {
+    return this.apiService.get<RosterResponse>('/roster');
+  }
+}

--- a/libs/roster/src/lib/roster.store.ts
+++ b/libs/roster/src/lib/roster.store.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { ComponentStore, OnStateInit, tapResponse } from '@ngrx/component-store';
+import { pipe } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { RosterService } from './roster.service';
+import { RosterEntry } from '@realworld/core/api-types';
+
+export interface RosterState {
+  roster: RosterEntry[];
+}
+
+@Injectable()
+export class RosterStoreService extends ComponentStore<RosterState> implements OnStateInit {
+  constructor(private readonly rosterService: RosterService) {
+    super({ roster: [] });
+  }
+
+  ngrxOnStateInit() {
+    this.loadRoster();
+  }
+
+  readonly roster$ = this.select((s) => s.roster);
+
+  readonly loadRoster = this.effect<void>(
+    pipe(
+      switchMap(() =>
+        this.rosterService.getRoster().pipe(
+          tapResponse(
+            (res) => this.patchState({ roster: res.roster }),
+            (error) => console.error('Error loading roster', error),
+          ),
+        ),
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- add backend roster service, controller, module and integrate into app module
- expose roster response types in api-types package
- implement angular roster store, service, component, and routing

## Testing
- `npm run lint` *(fails: nx not found)*
- `npm run test` *(fails: nx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68480c15dd4c8326b64ddc108626e79a