### PR TITLE
Add K'Route React Native skeleton

### DIFF
--- a/apps/kroute/README.md
+++ b/apps/kroute/README.md
@@ -1,0 +1,17 @@
+# K'Route – Kampala CBD Public Transport Navigator
+
+This directory contains a minimal React Native skeleton for the **K'Route** mobile application. The goal of this app is to help commuters in Kampala navigate matatu and boda-boda routes in the Central Business District.
+
+## Development
+
+The app is built with React Native. The root component is `src/App.tsx`. At this stage the implementation only provides a placeholder screen.
+
+Future iterations will include:
+
+- Interactive map displaying taxi stages and boda pickup points.
+- Search from origin to destination with multiple route options.
+- Live traffic reports and user-submitted jam information.
+- GPS tracking for nearby stages or bodas.
+- Offline access for saved routes.
+
+This repository currently does not include the React Native build tooling or dependencies required to run the application. These would typically be added with a package manager such as `yarn` or `npm` and may rely on additional Nx plugins for React Native support.

--- a/apps/kroute/src/App.tsx
+++ b/apps/kroute/src/App.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+// Placeholder for map component, e.g. react-native-maps MapView
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>K'Route</Text>
+      {/* Map component would be placed here */}
+      <Text>Map view placeholder</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 24, fontWeight: 'bold', marginBottom: 16 },
+});


### PR DESCRIPTION
## Summary
- create `kroute` React Native skeleton app with placeholder map view
- document K'Route app goals and future features

No tests were defined for this project.


------
https://chatgpt.com/codex/tasks/task_e_688532ae9c24832680abfc01b1144229