### PR TITLE
Add K'Route Nx project scaffolding

### DIFF
--- a/apps/kroute/README.md
+++ b/apps/kroute/README.md
@@ -1,0 +1,27 @@
+# K'Route – Kampala CBD Public Transport Navigator
+
+This directory contains the **K'Route** React Native application. It currently exposes a very small example but is structured as an Nx project so that it can be expanded later.
+
+## Development
+
+1. Install the workspace dependencies with `npm install` or `yarn`.
+2. The entry point for the app is `src/index.tsx` which registers the `App` component from `src/App.tsx`.
+3. Targets for running the app (android, ios, start) are defined in `project.json` but require the `@nx/react-native` plugin.
+
+Because the assessment environment does not include Node modules, the Nx tasks will not work until the dependencies are installed. In a full environment you would be able to run:
+
+```bash
+nx run kroute:start       # start the Metro bundler
+nx run kroute:android     # run on Android device or emulator
+nx run kroute:ios         # run on iOS simulator
+```
+
+## Future Features
+
+- Interactive map displaying taxi stages and boda pickup points.
+- Search from origin to destination with multiple route options and fare estimates.
+- Live traffic reports and user submitted jam information.
+- GPS tracking for nearby stages or bodas.
+- Offline access for saved routes.
+
+This app is an MVP placeholder and does not yet include dependencies such as React Navigation or mapping libraries.

--- a/apps/kroute/jest.config.ts
+++ b/apps/kroute/jest.config.ts
@@ -1,0 +1,11 @@
+/* eslint-disable */
+export default {
+  displayName: 'kroute',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../coverage/apps/kroute',
+};

--- a/apps/kroute/project.json
+++ b/apps/kroute/project.json
@@ -1,0 +1,35 @@
+{
+  "name": "kroute",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "sourceRoot": "apps/kroute/src",
+  "targets": {
+    "start": {
+      "executor": "@nx/react-native:start",
+      "options": {}
+    },
+    "android": {
+      "executor": "@nx/react-native:run-android",
+      "options": {}
+    },
+    "ios": {
+      "executor": "@nx/react-native:run-ios",
+      "options": {}
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/apps/kroute"],
+      "options": {
+        "jestConfig": "apps/kroute/jest.config.ts",
+        "passWithNoTests": true
+      }
+    },
+    "lint": {
+      "executor": "@nx/linter:eslint",
+      "options": {
+        "lintFilePatterns": ["apps/kroute/**/*.{ts,tsx,js,jsx}"]
+      }
+    }
+  },
+  "tags": []
+}

--- a/apps/kroute/src/App.spec.tsx
+++ b/apps/kroute/src/App.spec.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import App from './App';
+
+describe('App', () => {
+  it('should render title', () => {
+    // Placeholder test implementation
+    expect(App).toBeTruthy();
+  });
+});

--- a/apps/kroute/src/App.tsx
+++ b/apps/kroute/src/App.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View, Text, StyleSheet, TextInput } from 'react-native';
+// Placeholder for map component, e.g. react-native-maps MapView
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>K'Route</Text>
+      <TextInput placeholder="Where to?" style={styles.input} />
+      {/* Map component would be placed here */}
+      <Text>Map view placeholder</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+    justifyContent: 'flex-start',
+    alignItems: 'stretch',
+  },
+  title: { fontSize: 24, fontWeight: 'bold', marginVertical: 16, textAlign: 'center' },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    padding: 8,
+    marginBottom: 16,
+  },
+});

--- a/apps/kroute/src/index.tsx
+++ b/apps/kroute/src/index.tsx
@@ -1,0 +1,4 @@
+import { AppRegistry } from 'react-native';
+import App from './App';
+
+AppRegistry.registerComponent('kroute', () => App);

--- a/apps/kroute/tsconfig.app.json
+++ b/apps/kroute/tsconfig.app.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": ["react", "react-native"],
+    "jsx": "react"
+  },
+  "files": ["src/index.tsx"],
+  "exclude": ["**/*.spec.ts", "**/*.test.ts"]
+}

--- a/apps/kroute/tsconfig.json
+++ b/apps/kroute/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["jest", "react-native"],
+    "jsx": "react"
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.spec.json" }
+  ]
+}

--- a/apps/kroute/tsconfig.spec.json
+++ b/apps/kroute/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}


### PR DESCRIPTION
## Summary
- expand the `kroute` React Native skeleton with Nx configuration
- add project JSON with start/android/ios/test/lint targets
- include TypeScript configs and Jest setup
- update placeholder `App` component with simple search input
- document development steps in `apps/kroute/README.md`

## Testing
- `npm run format:write` *(fails: nx not found)*

------
https://chatgpt.com/codex/tasks/task_e_688532ae9c24832680abfc01b1144229